### PR TITLE
Fix custom post type preview

### DIFF
--- a/single.php
+++ b/single.php
@@ -8,5 +8,6 @@ $context['cancel_link'] = get_cancel_comment_reply_link(__('Cancel reply', 'base
 if (post_password_required($post->ID)) {
     Timber::render('single-password.twig', $context);
 } else {
-    Timber::render(['single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig'], $context);
+    $post_type = $post->post_type === 'revision' ? get_post_type($post->post_parent)  : $post->post_type;
+    Timber::render(['single-' . $post->ID . '.twig', 'single-' . $post_type . '.twig', 'single.twig'], $context);
 }


### PR DESCRIPTION
Hi,

this pull request address the "preview changes" functionality of Wordpress. In some cases the post type is equal to revision and doesn't match the page-[post_type].twig template for a specific custom post type.  

I added a check to get the post type from the parent post type and this fix the problem for what I have seen.
