### PR TITLE
Check for .env file before including phpdotenv

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -8,9 +8,11 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Init Timber
 $timber = new \Timber\Timber();
 
-// Init Dotenv
-$dotenv = new Dotenv\Dotenv(__DIR__ . '/..');
-$dotenv->load();
+// Init Dotenv if .env file is present
+if (file_exists(__DIR__ . '/../.env')) {
+    $dotenv = new Dotenv\Dotenv(__DIR__ . '/..');
+    $dotenv->load();
+}
 
 // Load WordPress config files
 require_once __DIR__ . '/../app/config/autoload.php';


### PR DESCRIPTION
Hi. (this is the same as #23 but I changed the source branch)

For anyone who is using Docker for either local development, deployment or infrastructure in general, or for anyone who is setting environments by hand as a choice (for example in production environments), there should be no necessity to load PHP dotenv.

It should load only if .env file is provided.

In docker-compose I'm always providing environment variables so there is no need to phpdotenv to load at all.

```
environment:
      MAINTENANCE: "false"
```

PHP dotenv should be used only as a tool for simulating environment variables in many environments where we do not want to bother with setting them each time you need an environment.

It shouldn't be used in production as well. See: https://github.com/vlucas/phpdotenv/issues/207

Also, another downside is that it is a problem for people using [bedrock](https://github.com/roots/bedrock) as an installation structure. Bedrock is using phpdotenv as well and in such case, one may want to omit using phpdotenv in the theme. Especially due to version difference (Bedrock is using v3, and Base camp is using v2), so there is a clear conflict as these two as not compatible.

I started working for a company that uses Base camp and I cannot stand, that every project I'm getting into, I have constant troubles with it :(